### PR TITLE
Add Code Coverage Reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-batch-koa",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-batch-koa",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Batch method for swatchjs-koa APIs",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "babel . -d dist --ignore coverage,dist,node_modules",
     "clean": "rm -rf dist/",
     "coveralls": "nyc report --reporter=text-lcov | ./node_modules/coveralls/bin/coveralls.js",
-    "codecov": "nyc report --reporter=lcov > coverage.lcov && codecov",
+    "codecov": "nyc report --reporter=lcov > coverage.lcov && codecov"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test:debug": "mocha --debug-brk",
     "lint": "./node_modules/.bin/eslint --ext .js index.js lib/**/*.js test/**/*.js",
     "build": "babel . -d dist --ignore coverage,dist,node_modules",
-    "clean": "rm -rf dist/"
+    "clean": "rm -rf dist/",
+    "coveralls": "nyc report --reporter=text-lcov | ./node_modules/coveralls/bin/coveralls.js",
+    "codecov": "nyc report --reporter=lcov > coverage.lcov && codecov",
   },
   "repository": {
     "type": "git",
@@ -42,8 +44,8 @@
     "bunyan": "^1.8.10",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
-    "codecov": "^2.3.0",
-    "coveralls": "^2.13.1",
+    "codecov": "^2.3.1",
+    "coveralls": "^2.13.3",
     "eslint-config-airbnb-base": "^11.3.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",


### PR DESCRIPTION
Use the [CircleCI build](https://circleci.com/gh/builtforme/swatchjs-batch-koa) to publish code coverage metrics to both [coveralls](https://coveralls.io/github/builtforme/swatchjs-batch-koa) and [codecov](https://codecov.io/gh/builtforme/swatchjs-batch-koa).