### PR TITLE
docs: add clarification for batch behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The `batchKoa` method returns a handler that takes the following parameters:
 |`ops[idx].args`    | Yes       | An object with the arguments to pass to the method.
 
 The methods are not guaranteed to be executed in any particular order, and they
-succeed or fail independently.
+succeed or fail independently. They are however guaranteed to be returned in the order in which they are recieved.
 
 The response will be an array of responses, where each response has the
 following properties:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The `batchKoa` method returns a handler that takes the following parameters:
 |`ops[idx].args`    | Yes       | An object with the arguments to pass to the method.
 
 The methods are not guaranteed to be executed in any particular order, and they
-succeed or fail independently. They are however guaranteed to be returned in the order in which they are recieved.
+succeed or fail independently. They are however guaranteed to be returned in the order in which they are received.
 
 The response will be an array of responses, where each response has the
 following properties:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-batch-koa",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Batch method for swatchjs-koa APIs",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Update to the documentation to clarify a technical point which we have been looking at. We are attempting to clarify that the behaviour of `swatch-batch-koa` is to execute ops in parallel but then reform the results such that they are returned in the order in which they are sent.